### PR TITLE
Exclude TestRunner from production build

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from 'react'
 import { motion } from 'framer-motion'
 import { Search, Moon, Sun } from 'lucide-react'
 
-function cx() { return Array.from(arguments).filter(Boolean).join(' ') }
+function cx(...args:any[]) { return args.filter(Boolean).join(' ') }
 
 const profile = {
   name: 'Saaed Imam',
@@ -178,31 +178,34 @@ export default function Page(){
         .btn-ghost:hover{ background:currentColor; color:var(--btn-fg,#fff) }
         .dark .btn-ghost:hover{ color:#000 }
       `}</style>
-      <TestRunner/>
+      {process.env.NODE_ENV !== 'production' && TestRunner && <TestRunner/>}
     </div>
   )
 }
 
-// TESTS — keep existing + add a few more
-function Badge(props){ return (<span style={{ display:'inline-block', marginRight:8, padding:'2px 6px', borderRadius:6, background: props.ok ? 'rgba(34,197,94,.15)' : 'rgba(239,68,68,.15)', color: props.ok ? '#16a34a' : '#ef4444', fontSize:11, border:`1px solid ${props.ok ? 'rgba(34,197,94,.4)' : 'rgba(239,68,68,.4)'}` }}>{props.label}</span>) }
+let TestRunner: React.FC | null = null
 
-function TestRunner(){
-  const [checks,setChecks] = useState([])
-  useEffect(()=>{
-    const r = []
-    const t1 = typeof cx === 'function'; console.assert(t1,'Test 1 failed: cx should be a function'); r.push({label:'cx available', ok:t1})
-    const t2 = !!document.getElementById('hero') && !!document.getElementById('projects'); console.assert(t2,'Test 2 failed: #hero and/or #projects missing'); r.push({label:'sections present', ok:t2})
-    const t3 = !!document.querySelector('header'); console.assert(t3,'Test 3 failed: <header> missing'); r.push({label:'header present', ok:t3})
-    const t4 = !!document.querySelector('.btn-ghost svg'); console.assert(t4,'Test 4 failed: theme toggle icon not found'); r.push({label:'theme toggle renders', ok:t4})
-    const t5 = !!Array.from(document.querySelectorAll('button')).find(b=> (b.textContent||'').includes('Command')); console.assert(t5,'Test 5 failed: Command palette button not found'); r.push({label:'cmd palette button', ok:t5})
-    const t6 = !!document.querySelector('main'); console.assert(t6,'Test 6 failed: <main> not present'); r.push({label:'main present', ok:t6})
-    const t7 = !!document.querySelector("a[href^='mailto:']"); console.assert(t7,'Test 7 failed: mailto link missing'); r.push({label:'mailto present', ok:t7})
-    const t8 = document.querySelectorAll('.group.rounded-2xl, .group.rounded-xl').length >= 3; console.assert(t8,'Test 8 failed: expected at least 3 project cards'); r.push({label:'cards render', ok:t8})
-    const t9 = !!document.querySelector('.fx-gradient'); console.assert(t9,'Test 9 failed: multicolor gradient missing'); r.push({label:'gradient active', ok:t9})
-    const t10 = !!document.querySelector('.fx-blob'); console.assert(t10,'Test 10 failed: blobs missing'); r.push({label:'blobs active', ok:t10})
-    const t11 = document.querySelectorAll('.fx-particle').length >= 10; console.assert(t11,'Test 11 failed: particles not seeded'); r.push({label:'particles seeded', ok:t11})
-    const t12 = !!document.querySelector('header .btn-ghost'); console.assert(t12,'Test 12 failed: theme toggle button missing'); r.push({label:'toggle button present', ok:t12})
-    setChecks(r)
-  },[])
-  return (<div style={{ position:'fixed', left:10, bottom:10, zIndex:9999 }}>{checks.map(c=> <Badge key={c.label} ok={c.ok} label={c.label}/>)}</div>)
+if (process.env.NODE_ENV !== 'production') {
+  const Badge = (props:{ ok:boolean, label:string }) => (<span style={{ display:'inline-block', marginRight:8, padding:'2px 6px', borderRadius:6, background: props.ok ? 'rgba(34,197,94,.15)' : 'rgba(239,68,68,.15)', color: props.ok ? '#16a34a' : '#ef4444', fontSize:11, border:`1px solid ${props.ok ? 'rgba(34,197,94,.4)' : 'rgba(239,68,68,.4)'}` }}>{props.label}</span>)
+
+  TestRunner = function TestRunner(){
+    const [checks,setChecks] = useState([])
+    useEffect(()=>{
+      const r = []
+      const t1 = typeof cx === 'function'; console.assert(t1,'Test 1 failed: cx should be a function'); r.push({label:'cx available', ok:t1})
+      const t2 = !!document.getElementById('hero') && !!document.getElementById('projects'); console.assert(t2,'Test 2 failed: #hero and/or #projects missing'); r.push({label:'sections present', ok:t2})
+      const t3 = !!document.querySelector('header'); console.assert(t3,'Test 3 failed: <header> missing'); r.push({label:'header present', ok:t3})
+      const t4 = !!document.querySelector('.btn-ghost svg'); console.assert(t4,'Test 4 failed: theme toggle icon not found'); r.push({label:'theme toggle renders', ok:t4})
+      const t5 = !!Array.from(document.querySelectorAll('button')).find(b=> (b.textContent||'').includes('Command')); console.assert(t5,'Test 5 failed: Command palette button not found'); r.push({label:'cmd palette button', ok:t5})
+      const t6 = !!document.querySelector('main'); console.assert(t6,'Test 6 failed: <main> not present'); r.push({label:'main present', ok:t6})
+      const t7 = !!document.querySelector("a[href^='mailto:']"); console.assert(t7,'Test 7 failed: mailto link missing'); r.push({label:'mailto present', ok:t7})
+      const t8 = document.querySelectorAll('.group.rounded-2xl, .group.rounded-xl').length >= 3; console.assert(t8,'Test 8 failed: expected at least 3 project cards'); r.push({label:'cards render', ok:t8})
+      const t9 = !!document.querySelector('.fx-gradient'); console.assert(t9,'Test 9 failed: multicolor gradient missing'); r.push({label:'gradient active', ok:t9})
+      const t10 = !!document.querySelector('.fx-blob'); console.assert(t10,'Test 10 failed: blobs missing'); r.push({label:'blobs active', ok:t10})
+      const t11 = document.querySelectorAll('.fx-particle').length >= 10; console.assert(t11,'Test 11 failed: particles not seeded'); r.push({label:'particles seeded', ok:t11})
+      const t12 = !!document.querySelector('header .btn-ghost'); console.assert(t12,'Test 12 failed: theme toggle button missing'); r.push({label:'toggle button present', ok:t12})
+      setChecks(r)
+    },[])
+    return (<div style={{ position:'fixed', left:10, bottom:10, zIndex:9999 }}>{checks.map(c=> <Badge key={c.label} ok={c.ok} label={c.label}/>)}</div>)
+  }
 }


### PR DESCRIPTION
### **User description**
## Summary
- only include TestRunner and dev-only badge tests outside of production
- allow `cx` helper to accept variadic arguments

## Testing
- `npm run lint` *(fails: prompts for interactive config)*
- `npm run build`
- `rg TestRunner .next || echo 'no matches'`


------
https://chatgpt.com/codex/tasks/task_e_68bf872f4e60832994f8cc5611433944


___

### **PR Type**
Enhancement


___

### **Description**
- Exclude TestRunner component from production builds

- Improve cx helper function with variadic arguments

- Wrap dev-only components with environment checks


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["cx helper"] -- "enhanced with" --> B["variadic arguments"]
  C["TestRunner"] -- "wrapped with" --> D["NODE_ENV check"]
  D -- "excluded from" --> E["production build"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Conditional TestRunner rendering and cx enhancement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pages/index.tsx

<ul><li>Enhanced <code>cx</code> helper function to accept variadic arguments with proper <br>TypeScript typing<br> <li> Wrapped TestRunner component with NODE_ENV check to exclude from <br>production<br> <li> Moved TestRunner and Badge components inside conditional block<br> <li> Added null initialization for TestRunner variable</ul>


</details>


  </td>
  <td><a href="https://github.com/saaedimam/Potato/pull/2/files#diff-aa98fd0757d0e1741503c50cfafb7726939d19819638bbe8e030a27adfec34a3">+26/-23</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

